### PR TITLE
More natural sorting order.

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 function getKey(s) {
-  return (s.split('//')[1] || s).split('.').slice(-2).join('.'))
+  return (s.split('//')[1] || s).split('.').slice(-2).join('.')
 }
 
 function sortTabs(a, b) {

--- a/background.js
+++ b/background.js
@@ -1,5 +1,5 @@
 function getKey(s) {
-  return (s.split('//')[1] || s).split('.').slice(-2).join('.')
+  return (s.split('//')[1] || s).split('.').slice(-2).join('.'))
 }
 
 function sortTabs(a, b) {

--- a/background.js
+++ b/background.js
@@ -1,5 +1,9 @@
+function getKey(s) {
+  return (s.split('//')[1] || s).split('.').slice(-2).join('.')
+}
+
 function sortTabs(a, b) {
-  return (a.url.split('//')[1] || a.url) > (b.url.split('//')[1] || b.url);
+  return (getKey(a.url)) > (getKey(b.url));
 }
 
 function sortTabsInverted(a, b) {


### PR DESCRIPTION
This patch discards subdomains from the sort key, making for a more natural sorting order.

for example `www.youtube.com/...` is sorted under `youtube.com`
likewise `en.wikipedia.com` is sorted under `wikipedia.com`
Generally this will line up with user's expectations of what sites are called a bit better.
the issue exists that websites using multiple subdomains will now be grouped together, however in most cases this will probably also reduce confusion. IE `web.whatsapp.com`